### PR TITLE
Fixed Height Issue in Contact Page and Font Issues

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -14,7 +14,9 @@ const Contact: FC = () => {
     <>
       <Header />
       <main
-        className="h-[90vh] flex w-full flex-col items-center bg-white dark:bg-slate-800"
+        className={`h-${
+          width > 640 ? "[90vh]" : "fit"
+        } flex w-full flex-col items-center bg-white dark:bg-slate-800`}
         style={{ minHeight: 600 }}
       >
         <h1 className="mt-10 text-3xl font-montserrat">Contact</h1>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -26,11 +26,7 @@ export default function RootLayout({
     <html lang="en">
       <head>
         <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link
-          rel="preconnect"
-          href="https://fonts.gstatic.com"
-          crossOrigin=""
-        />
+        <link rel="preconnect" href="https://fonts.gstatic.com" />
         <link
           href="https://fonts.googleapis.com/css2?family=Montserrat:wght@500&family=Raleway:wght@500&family=Raleway:wght@500&display=swap"
           rel="stylesheet"


### PR DESCRIPTION
Fixed the issue where the contact cards do not fit in the height of the contact page on mobile view. Additionally, fixed the "resource preloaded but not used" error thanks to this issue thread: https://github.com/gatsbyjs/gatsby/issues/14872